### PR TITLE
Quick null nullables

### DIFF
--- a/src/Nullable.php
+++ b/src/Nullable.php
@@ -57,6 +57,14 @@ abstract class Nullable implements ValueObject
     }
 
     /**
+     * @return static
+     */
+    public static function null()
+    {
+        return static::fromNative(null);
+    }
+
+    /**
      * @return mixed
      */
     public function toNative()

--- a/src/NullableTest.php
+++ b/src/NullableTest.php
@@ -71,6 +71,12 @@ final class NullableTest extends TestCase
         $this->assertEquals('non-null-implementation', $test->toNative());
     }
 
+    public function test_null_creates_a_nullable_backed_by_the_null_implementation()
+    {
+        $test = _Nullable::null();
+        $this->assertEquals('null-implementation', $test->toNative());
+    }
+
     public function tearDown()
     {
         Mockery::close();


### PR DESCRIPTION
Added a helper function to nullable to quickly create null backed nullables.

We've found ourselves doing the following rather frequently:
`$null = Nullable::fromNative(null);`

Just to be (slightly) quicker, but also to better show intent, this PR introduces the following shorthand:
`$null = Nullable::null();`